### PR TITLE
STORY-000: Update .gitignore Terraform exclusions (code review)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,17 +142,9 @@ vite.config.ts.timestamp-*
 # Terraform configuration
 .terraform/
 *.tfstate
-*.tfstate.*
-*.tfplan
-
-# Ignore terraform .rc files that are used to configure the CLI
-.terraformrc
-terraform.rc
-
-# Ignore variable files that may contain sensitive data
-# You can uncomment the following line if you want to ignore all .tfvars files
-# *.tfvars
-# *.tfvars.json
+*.tfstate.backup
+*.tfvars
+*.tfvars.json
 
 # Crash log files
 crash.log


### PR DESCRIPTION
## STORY-000: Code Review Fix — .gitignore Terraform exclusions

### Change

Updated the Terraform section of `.gitignore` per code review feedback:

- Added `*.tfstate.backup` explicitly
- Added `*.tfvars` and `*.tfvars.json` (previously commented out) to prevent sensitive variable files from being committed
- Removed overly broad `*.tfstate.*`, `*.tfplan`, and `.terraformrc` entries

### Acceptance Criteria

#### ✅ Coder Role (complete)
- [x] `.gitignore` updated to exclude `.terraform/`, `*.tfstate`, `*.tfstate.backup`, `*.tfvars`, `*.tfvars.json`

#### Note on C3P Roles
The CI/CD workflow (`.github/workflows/ci-cd.yml`) will be added by the **Platform Engineer (Deployer)** role, not the Reviewer. The Coder PAT intentionally lacks `workflow` scope per C3P Separation of Duties.