### PR TITLE
STORY-000: Add timestamp to Hello World response

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -4,7 +4,7 @@ export function createApp(): Application {
   const app = express();
 
   app.get('/', (_req: Request, res: Response) => {
-    res.json({ message: 'Hello World', status: 'ok' });
+    res.json({ message: 'Hello World', status: 'ok', timestamp: new Date().toISOString() });
   });
 
   app.get('/health', (_req: Request, res: Response) => {

--- a/tests/functional/api.test.ts
+++ b/tests/functional/api.test.ts
@@ -12,6 +12,11 @@ describe('API Functional Tests', () => {
       expect(response.body.status).toBe('ok');
     });
 
+    it('should include a valid ISO 8601 timestamp', async () => {
+      const response = await request(app).get('/');
+      expect(response.body.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+
     it('should return JSON content-type', async () => {
       const response = await request(app).get('/');
       expect(response.headers['content-type']).toMatch(/json/);


### PR DESCRIPTION
## STORY-000: Add timestamp to Hello World response

### Change

Added a UTC timestamp to the `GET /` response to exercise the full C3P deployment lifecycle end-to-end.

**Before:**
```json
{ "message": "Hello World", "status": "ok" }
```

**After:**
```json
{ "message": "Hello World", "status": "ok", "timestamp": "2026-03-01T12:34:56.789Z" }
```

### Tests updated

- `tests/functional/api.test.ts` — new assertion validates the `timestamp` field matches ISO 8601 format (`/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/`)
- Unit and smoke tests unchanged (no new utility functions; smoke tests verify accessibility only)

### Acceptance Criteria

#### ✅ Coder Role (complete)
- [x] `GET /` response includes a `timestamp` field with current UTC time in ISO 8601 format
- [x] Functional test added and passing locally
- [x] All unit, functional, and smoke tests green

#### ⏳ Platform Engineer (Deployer) / SRE Role (pending)
- [ ] CI pipeline runs unit tests on this PR
- [ ] Docker image built and published to GHCR on merge
- [ ] Deployed to GKE Test cluster; functional tests pass
- [ ] Pipeline pauses for `C3P-SRE` approval
- [ ] Deployed to GKE Production cluster; smoke tests pass
- [ ] C3P Evidence Pack generated