### PR TITLE
STORY-001a: Inject FRED_API_KEY from K8s Secret (Platform Engineer)

### DIFF
--- a/k8s/prod/deployment.yaml
+++ b/k8s/prod/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: crisis-monitor-prod
   labels:
     app: crisis-monitor
-    story: STORY-000
+    story: STORY-001a
     environment: production
 spec:
   replicas: 2
@@ -28,6 +28,11 @@ spec:
               value: "production"
             - name: PORT
               value: "3000"
+            - name: FRED_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: fred-api-credentials
+                  key: api-key
           resources:
             requests:
               cpu: "250m"

--- a/k8s/test/deployment.yaml
+++ b/k8s/test/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: crisis-monitor-test
   labels:
     app: crisis-monitor
-    story: STORY-000
+    story: STORY-001a
     environment: test
 spec:
   replicas: 1
@@ -28,6 +28,11 @@ spec:
               value: "test"
             - name: PORT
               value: "3000"
+            - name: FRED_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: fred-api-credentials
+                  key: api-key
           resources:
             requests:
               cpu: "250m"


### PR DESCRIPTION
## Summary

- Updates `k8s/test/deployment.yaml` and `k8s/prod/deployment.yaml` to inject `FRED_API_KEY` as an env var sourced from a Kubernetes Secret.
- No plain-text secret value appears in any manifest.
- Story label updated from `STORY-000` → `STORY-001a` on both Deployment resources.

## Secret Reference

```yaml
- name: FRED_API_KEY
  valueFrom:
    secretKeyRef:
      name: fred-api-credentials
      key: api-key
```

The Kubernetes Secret (`fred-api-credentials`) must be pre-provisioned in each namespace (`crisis-monitor-test` and `crisis-monitor-prod`) before the Deployment is applied. The Secret value is sourced from the `FRED_API_KEY` GitHub Actions secret, which must be added to **Settings → Secrets → Actions** and scoped to both the **Test** and **Production** environments (manual step — cannot be done via code).

## Pre-deployment checklist for SRE

- [ ] `FRED_API_KEY` added to GitHub Actions secrets, scoped to `Test` and `Production` environments.
- [ ] Kubernetes Secret `fred-api-credentials` created in `crisis-monitor-test` namespace:
  ```
  kubectl create secret generic fred-api-credentials \
    --from-literal=api-key=<VALUE> \
    -n crisis-monitor-test
  ```
- [ ] Kubernetes Secret `fred-api-credentials` created in `crisis-monitor-prod` namespace:
  ```
  kubectl create secret generic fred-api-credentials \
    --from-literal=api-key=<VALUE> \
    -n crisis-monitor-prod
  ```

## C3P Compliance

- Platform Engineer PR only — no application logic touched.
- Follows C3P branch protection; requires Reviewer approval before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)