### PR TITLE
fix(#23): Trim FRED_API_KEY and add live-endpoint smoke tests

### DIFF
--- a/src/connectors/fred/fredConnector.ts
+++ b/src/connectors/fred/fredConnector.ts
@@ -21,7 +21,7 @@ function normalizeObservations(
 }
 
 async function fetchIndicators(indicators: IndicatorConfig[]): Promise<IndicatorObservation[]> {
-  const apiKey = process.env.FRED_API_KEY;
+  const apiKey = process.env.FRED_API_KEY?.trim();
   if (!apiKey) {
     throw new Error('FRED_API_KEY environment variable is not set');
   }

--- a/tests/smoke/smoke.test.ts
+++ b/tests/smoke/smoke.test.ts
@@ -1,17 +1,50 @@
+/**
+ * Smoke Tests
+ *
+ * When BASE_URL is set (post-deployment in CI/CD), tests hit the live cluster
+ * service via HTTP — this is the true post-deploy sanity check.
+ *
+ * Without BASE_URL (local dev), tests fall back to an in-process supertest
+ * server so the suite can still be run locally.
+ */
 import request from 'supertest';
 import { createApp } from '../../src/app';
 
-const app = createApp();
+const BASE_URL = process.env.BASE_URL;
+
+type JsonBody = Record<string, unknown>;
+
+async function get(path: string): Promise<{ status: number; body: JsonBody }> {
+  if (BASE_URL) {
+    const res = await fetch(`${BASE_URL}${path}`);
+    const body = (await res.json()) as JsonBody;
+    return { status: res.status, body };
+  }
+  const res = await request(createApp()).get(path);
+  return { status: res.status, body: res.body as JsonBody };
+}
 
 describe('Smoke Tests', () => {
-  it('server responds to requests', async () => {
-    const response = await request(app).get('/health');
-    expect(response.status).toBe(200);
+  it(`GET /health returns 200 [${BASE_URL ?? 'in-process'}]`, async () => {
+    const { status, body } = await get('/health');
+    expect(status).toBe(200);
+    expect(body.status).toBe('healthy');
   });
 
-  it('main endpoint is accessible', async () => {
-    const response = await request(app).get('/');
-    expect(response.status).toBe(200);
-    expect(response.body).toHaveProperty('message');
+  it(`GET / returns 200 with Hello World [${BASE_URL ?? 'in-process'}]`, async () => {
+    const { status, body } = await get('/');
+    expect(status).toBe(200);
+    expect(body.message).toBe('Hello World');
+  });
+
+  it(`GET /api/health/fred returns 200 with all four indicator sets [${BASE_URL ?? 'in-process'}]`, async () => {
+    const { status, body } = await get('/api/health/fred');
+    expect(status).toBe(200);
+    expect(body.status).toBe('ok');
+    const indicators = body.indicators as JsonBody;
+    expect(indicators).toHaveProperty('yieldCurve');
+    expect(indicators).toHaveProperty('creditSpreads');
+    expect(indicators).toHaveProperty('unemployment');
+    expect(indicators).toHaveProperty('pmi');
   });
 });

--- a/tests/unit/connectors/fredConnector.test.ts
+++ b/tests/unit/connectors/fredConnector.test.ts
@@ -94,6 +94,16 @@ describe('fetchYieldCurveData()', () => {
     await expect(fetchYieldCurveData()).rejects.toThrow('FRED_API_KEY environment variable is not set');
     expect(mockFetchFredSeries).not.toHaveBeenCalled();
   });
+
+  it('trims whitespace from FRED_API_KEY before use (guards against K8s secret trailing newline)', async () => {
+    process.env.FRED_API_KEY = '  test-api-key\n';
+    mockFetchFredSeries.mockResolvedValue({ observations: [] });
+
+    await fetchYieldCurveData();
+
+    expect(mockFetchFredSeries).toHaveBeenCalledWith('DGS10', 'test-api-key');
+    expect(mockFetchFredSeries).toHaveBeenCalledWith('DGS2', 'test-api-key');
+  });
 });
 
 // STORY-001b


### PR DESCRIPTION
Closes #23

## Changes

Two fixes per Platform Engineer code review on issue #23.

### Fix 1 — `FRED_API_KEY` trimming (`src/connectors/fred/fredConnector.ts`)

```typescript
// Before
const apiKey = process.env.FRED_API_KEY;

// After
const apiKey = process.env.FRED_API_KEY?.trim();
```

A trailing `\n` from a K8s secret created with `--from-file` is truthy, passes the `!apiKey` guard, but gets URL-encoded as `%0A` causing FRED to return 400. `.trim()` eliminates this entire class of secret-provisioning error permanently.

**New unit test** verifies `'  test-api-key\n'` is trimmed to `'test-api-key'` before reaching `fetchFredSeries()`.

---

### Fix 2 — Live-endpoint smoke tests (`tests/smoke/smoke.test.ts`)

The previous smoke test used supertest (in-process) and could not detect the failure reported in #23.

Smoke tests now use `BASE_URL` when set by the deploy script, hitting the **live cluster service** over HTTP:

| `BASE_URL` set? | Behaviour |
|---|---|
| ✅ Yes (CI/CD post-deploy) | `fetch()` against live LoadBalancer IP — real E2E validation |
| ❌ No (local dev) | supertest in-process fallback |

**Three endpoints tested:**
- `GET /health` — basic liveness
- `GET /` — app is running
- `GET /api/health/fred` — FRED credentials + all four connectors working

The `/api/health/fred` smoke test will **fail** if FRED returns 400 or 503, surfacing K8s secret misconfiguration immediately after deployment. This is the test that would have caught issue #23 automatically.

**Note for Platform Engineer:** `deploy_test.sh` should export `BASE_URL` pointing to the Test cluster's LoadBalancer IP before calling `npm run test:smoke`.

---

## Test results
- Unit: 23 passed ✅
- Functional: 6 passed ✅
- Smoke (local, no `FRED_API_KEY`): `/api/health/fred` correctly returns 503 → test fails as expected, proving the smoke test genuinely detects FRED misconfiguration