### PR TITLE
STORY-001e: Export BASE_URL in deploy_prod.sh for live smoke tests

### DIFF
--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -27,7 +27,17 @@ envsubst '${IMAGE_TAG}' < k8s/prod/deployment.yaml | kubectl apply -f -
 echo "Waiting for rollout to complete..."
 kubectl rollout status deployment/crisis-monitor -n crisis-monitor-prod --timeout=300s
 
-echo "Running Post-Release Smoke Tests..."
+echo "Getting Production LoadBalancer IP..."
+PROD_IP=$(kubectl get service crisis-monitor -n crisis-monitor-prod \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+if [ -z "$PROD_IP" ]; then
+  echo "Error: Could not retrieve Production LoadBalancer IP. Aborting smoke tests."
+  exit 1
+fi
+
+export BASE_URL="http://${PROD_IP}"
+echo "Running Post-Release Smoke Tests against ${BASE_URL}..."
 npm run test:smoke
 
 echo "Production Deployment Complete. Generating Final Compliance Evidence Pack."


### PR DESCRIPTION
## Summary

- Fetches the Production LoadBalancer IP after `kubectl rollout status` completes
- Exports it as `BASE_URL` before calling `npm run test:smoke`
- Aborts with a clear error if the IP cannot be retrieved

## Why

`deploy_prod.sh` already called `npm run test:smoke` but never set `BASE_URL`. Without it the smoke test silently fell back to in-process supertest mode — mocking the real cluster entirely and providing no genuine post-deployment validation.

With this change the smoke test will:
- Hit `GET /health`, `GET /`, and `GET /api/health/fred` on the live Production LoadBalancer IP
- Fail the pipeline (and block C3P evidence generation) if FRED returns anything other than 200 — catching secret misconfiguration of the type seen in issue #23 automatically

## Addresses

Reviewer note on PR #27: "it is `deploy_prod.sh` that calls `npm run test:smoke`. `BASE_URL` should be exported in `deploy_prod.sh`, pointed at the Production LoadBalancer IP, before the smoke test step."

Closes #23 pipeline validation gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)