### PR TITLE
BUG-23: PE — Dockerfile build args, pipeline wiring, smoke test exports

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -59,6 +59,10 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract package version
+        id: pkg
+        run: echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v5
         with:
@@ -67,6 +71,9 @@ jobs:
           tags: |
             ${{ env.IMAGE_REPO }}:${{ github.sha }}
             ${{ env.IMAGE_REPO }}:latest
+          build-args: |
+            GIT_SHA=${{ github.sha }}
+            VERSION=${{ steps.pkg.outputs.version }}
 
   # ============================================================
   # STAGE 3: Deploy to Test + Run Functional Tests

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,11 @@ RUN npm run build
 # Production stage
 FROM node:20-alpine AS production
 WORKDIR /app
+ARG GIT_SHA=dev
+ARG VERSION=unknown
 ENV NODE_ENV=production
+ENV GIT_SHA=$GIT_SHA
+ENV VERSION=$VERSION
 COPY package*.json ./
 RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -37,7 +37,8 @@ if [ -z "$PROD_IP" ]; then
 fi
 
 export BASE_URL="http://${PROD_IP}"
-echo "Running Post-Release Smoke Tests against ${BASE_URL}..."
+export EXPECTED_GIT_SHA="${GITHUB_SHA}"
+echo "Running Post-Release Smoke Tests against ${BASE_URL} (expecting SHA ${EXPECTED_GIT_SHA})..."
 npm run test:smoke
 
 echo "Production Deployment Complete. Generating Final Compliance Evidence Pack."

--- a/scripts/deploy_test.sh
+++ b/scripts/deploy_test.sh
@@ -28,4 +28,18 @@ kubectl rollout status deployment/crisis-monitor -n crisis-monitor-test --timeou
 echo "Running Functional / Regression Tests..."
 npm run test:functional
 
+echo "Getting Test LoadBalancer IP..."
+TEST_IP=$(kubectl get service crisis-monitor -n crisis-monitor-test \
+  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+
+if [ -z "$TEST_IP" ]; then
+  echo "Error: Could not retrieve Test LoadBalancer IP. Aborting smoke tests."
+  exit 1
+fi
+
+export BASE_URL="http://${TEST_IP}"
+export EXPECTED_GIT_SHA="${GITHUB_SHA}"
+echo "Running Smoke Tests against ${BASE_URL} (expecting SHA ${EXPECTED_GIT_SHA})..."
+npm run test:smoke
+
 echo "Test Environment Deployment and Validation Complete."


### PR DESCRIPTION
## PE task list items from PR #32 cross-role checklist

Implements all four Platform Engineer items assigned by the Reviewer on PR #32.

## Changes

### Dockerfile
- Added `ARG GIT_SHA=dev` and `ARG VERSION=unknown` to the production stage
- Added matching `ENV GIT_SHA=$GIT_SHA` and `ENV VERSION=$VERSION` so the running container exposes both values to `process.env`

### `.github/workflows/ci-cd.yml`
- Added an **Extract package version** step (reads `package.json` via `node -p`) before the Docker build
- Passes `GIT_SHA` and `VERSION` as `build-args` to `docker/build-push-action`

### `scripts/deploy_prod.sh`
- Exports `EXPECTED_GIT_SHA=${GITHUB_SHA}` alongside the existing `BASE_URL` before `npm run test:smoke`

### `scripts/deploy_test.sh`
- Resolves the Test environment LoadBalancer IP after rollout
- Exports `BASE_URL` and `EXPECTED_GIT_SHA=${GITHUB_SHA}`
- Calls `npm run test:smoke` after the existing `npm run test:functional`

## Cross-role task checklist (PE items)

- [x] Add `ARG GIT_SHA=dev` / `ARG VERSION=unknown` and corresponding `ENV` lines to `Dockerfile`
- [x] Add `--build-arg GIT_SHA=...` and `--build-arg VERSION=...` to the `docker/build-push-action` step in `ci-cd.yml`
- [x] Add `EXPECTED_GIT_SHA` export to `deploy_prod.sh`
- [x] Add `BASE_URL` and `EXPECTED_GIT_SHA` exports to `deploy_test.sh`

Linked to PR #32 — Reviewer should verify both PRs together before approving either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)