### PR TITLE
chore: remove compiled JS artefacts from tests/ and update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,5 @@ vite.config.ts.timestamp-*
 # Crash log files
 crash.log
 
+# Compiled test artefacts (tsc output before outDir was set)
+tests/**/*.js


### PR DESCRIPTION
## Summary
- Deleted 6 compiled `.js` files left in `tests/` from a `tsc` run before `outDir: ./dist` was configured — they shadowed their `.ts` counterparts and created noise in `git status`
- Added `tests/**/*.js` to `.gitignore` to prevent recurrence

## Files changed
- `.gitignore` — 2 lines added

## Test plan
- [ ] `npm run test:unit` passes (`.ts` source files untouched)
- [ ] `npm run test:functional` passes
- [ ] `git status` shows clean working tree after checkout

🤖 Generated with [Claude Code](https://claude.com/claude-code)