### PR TITLE
PE: skip CI/CD pipeline for non-deployment merges to main

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,6 +6,16 @@ on:
     branches: [main]
   push:
     branches: [main]
+    paths-ignore:
+      # Documentation and role instructions — no deployment impact
+      - '**/*.md'
+      # Task tracking files
+      - 'tasks/**'
+      # Repo housekeeping
+      - '.gitignore'
+      - 'LICENSE'
+      # Terraform infrastructure (managed separately, not part of app pipeline)
+      - 'infra/**'
 
 env:
   # Docker requires repository names to be strictly lowercase


### PR DESCRIPTION
## Problem

Every merge to `main` triggers the full pipeline — unit tests, Docker build, GKE deploy to Test, SRE gate, GKE deploy to Production. Documentation tidying, task file updates, and role-instruction changes were all causing unnecessary K8s runs and GCP costs.

## Change

Added `paths-ignore` to the `push` trigger in `ci-cd.yml`.

**Ignored (pipeline skipped on push to main):**
| Pattern | Covers |
|---|---|
| `**/*.md` | All markdown: docs, role files, PRD, reports |
| `tasks/**` | Backlog, in-progress, and done task files |
| `.gitignore` | Git config |
| `LICENSE` | Licence file |
| `infra/**` | Terraform — managed separately, not part of the app pipeline |

**Not ignored (pipeline still runs):**
`src/**`, `tests/**`, `Dockerfile`, `.dockerignore`, `k8s/**`, `scripts/**`, `.github/workflows/**`, `package*.json`, `tsconfig.json`, `jest.config.js`

## What is unchanged

The `pull_request` trigger has **no** path filter — unit tests still run on every PR regardless of what changed. This preserves the CI gate the Reviewer relies on.

## Cost impact

Merges that only touch docs or tasks (which happen frequently as stories complete) will no longer spin up GKE nodes or trigger cloud deployments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)