### PR TITLE
PE: Migrate CI/CD from GKE to Hostinger VPS SSH+Docker

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -20,9 +20,6 @@ on:
 env:
   # Docker requires repository names to be strictly lowercase
   IMAGE_REPO: ghcr.io/pgallc/crisis_monitor
-  GCP_PROJECT_ID: paulgresham-com
-  GKE_CLUSTER_NAME: crisis-monitor-cluster
-  GKE_CLUSTER_ZONE: us-east1
 
 jobs:
   # ============================================================
@@ -97,21 +94,17 @@ jobs:
     environment: Test
     env:
       IMAGE_TAG: ghcr.io/pgallc/crisis_monitor:${{ github.sha }}
+      VPS_HOST: ${{ secrets.VPS_HOST }}
+      FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Get GKE Credentials
-        uses: google-github-actions/get-gke-credentials@v2
-        with:
-          cluster_name: ${{ env.GKE_CLUSTER_NAME }}
-          location: ${{ env.GKE_CLUSTER_ZONE }}
-          project_id: ${{ env.GCP_PROJECT_ID }}
+      - name: Write SSH deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
 
       - uses: actions/setup-node@v4
         with:
@@ -139,21 +132,17 @@ jobs:
     environment: Production
     env:
       IMAGE_TAG: ghcr.io/pgallc/crisis_monitor:${{ github.sha }}
+      VPS_HOST: ${{ secrets.VPS_HOST }}
+      FRED_API_KEY: ${{ secrets.FRED_API_KEY }}
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate to GCP
-        uses: google-github-actions/auth@v2
-        with:
-          credentials_json: ${{ secrets.GCP_SA_KEY }}
-
-      - name: Get GKE Credentials
-        uses: google-github-actions/get-gke-credentials@v2
-        with:
-          cluster_name: ${{ env.GKE_CLUSTER_NAME }}
-          location: ${{ env.GKE_CLUSTER_ZONE }}
-          project_id: ${{ env.GCP_PROJECT_ID }}
+      - name: Write SSH deploy key
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.VPS_SSH_KEY }}" > ~/.ssh/id_deploy
+          chmod 600 ~/.ssh/id_deploy
 
       - uses: actions/setup-node@v4
         with:

--- a/scripts/deploy_prod.sh
+++ b/scripts/deploy_prod.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-# C3P Stage: Deploy to Production
+# C3P Stage: Deploy to Production (Hostinger VPS via SSH+Docker)
 # Executed strictly by the CI/CD pipeline after SRE approval and Test success
 
 echo "--- C3P Deploy to PROD ---"
@@ -18,26 +18,51 @@ if [ -z "$IMAGE_TAG" ]; then
   exit 1
 fi
 
-echo "Deploying image ${IMAGE_TAG} to Production environment..."
-
-# Apply namespace and deployment manifests using envsubst to inject IMAGE_TAG
-envsubst '${IMAGE_TAG}' < k8s/prod/namespace.yaml | kubectl apply -f -
-envsubst '${IMAGE_TAG}' < k8s/prod/deployment.yaml | kubectl apply -f -
-
-echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/crisis-monitor -n crisis-monitor-prod --timeout=300s
-
-echo "Getting Production LoadBalancer IP..."
-PROD_IP=$(kubectl get service crisis-monitor -n crisis-monitor-prod \
-  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-if [ -z "$PROD_IP" ]; then
-  echo "Error: Could not retrieve Production LoadBalancer IP. Aborting smoke tests."
+if [ -z "$VPS_HOST" ]; then
+  echo "Error: VPS_HOST environment variable is not set."
   exit 1
 fi
 
-export BASE_URL="http://${PROD_IP}"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/id_deploy"
+SSH_CMD="ssh $SSH_OPTS deploy@${VPS_HOST}"
+
+echo "Deploying image ${IMAGE_TAG} to Production environment on ${VPS_HOST}..."
+
+echo "Pulling image on VPS..."
+$SSH_CMD "docker pull ${IMAGE_TAG}"
+
+echo "Stopping existing production container (if any)..."
+$SSH_CMD "docker stop crisis-monitor-prod && docker rm crisis-monitor-prod" || true
+
+echo "Starting new production container..."
+$SSH_CMD "docker run -d \
+  --name crisis-monitor-prod \
+  --restart unless-stopped \
+  -p 3002:3000 \
+  -e NODE_ENV=production \
+  -e FRED_API_KEY=${FRED_API_KEY} \
+  -e GIT_SHA=${GITHUB_SHA} \
+  ${IMAGE_TAG}"
+
+echo "Waiting for container to become healthy..."
+TIMEOUT=60
+ELAPSED=0
+until curl -sf "http://${VPS_HOST}:3002/health" > /dev/null 2>&1; do
+  if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    echo "Error: Production container did not become healthy within ${TIMEOUT}s."
+    $SSH_CMD "docker logs crisis-monitor-prod" || true
+    exit 1
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+  echo "  waiting... (${ELAPSED}s / ${TIMEOUT}s)"
+done
+
+echo "Production container is healthy."
+
+export BASE_URL="http://${VPS_HOST}:3002"
 export EXPECTED_GIT_SHA="${GITHUB_SHA}"
+
 echo "Running Post-Release Smoke Tests against ${BASE_URL} (expecting SHA ${EXPECTED_GIT_SHA})..."
 npm run test:smoke
 

--- a/scripts/deploy_test.sh
+++ b/scripts/deploy_test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-# C3P Stage: Deploy to Test Environment
+# C3P Stage: Deploy to Test Environment (Hostinger VPS via SSH+Docker)
 # Executed strictly by the CI/CD pipeline (Deployer Role)
 
 echo "--- C3P Deploy to TEST ---"
@@ -16,29 +16,54 @@ if [ -z "$IMAGE_TAG" ]; then
   exit 1
 fi
 
-echo "Deploying image ${IMAGE_TAG} to Test environment..."
-
-# Apply namespace and deployment manifests using envsubst to inject IMAGE_TAG
-envsubst '${IMAGE_TAG}' < k8s/test/namespace.yaml | kubectl apply -f -
-envsubst '${IMAGE_TAG}' < k8s/test/deployment.yaml | kubectl apply -f -
-
-echo "Waiting for rollout to complete..."
-kubectl rollout status deployment/crisis-monitor -n crisis-monitor-test --timeout=300s
-
-echo "Running Functional / Regression Tests..."
-npm run test:functional
-
-echo "Getting Test LoadBalancer IP..."
-TEST_IP=$(kubectl get service crisis-monitor -n crisis-monitor-test \
-  -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-if [ -z "$TEST_IP" ]; then
-  echo "Error: Could not retrieve Test LoadBalancer IP. Aborting smoke tests."
+if [ -z "$VPS_HOST" ]; then
+  echo "Error: VPS_HOST environment variable is not set."
   exit 1
 fi
 
-export BASE_URL="http://${TEST_IP}"
+SSH_OPTS="-o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -i ~/.ssh/id_deploy"
+SSH_CMD="ssh $SSH_OPTS deploy@${VPS_HOST}"
+
+echo "Deploying image ${IMAGE_TAG} to Test environment on ${VPS_HOST}..."
+
+echo "Pulling image on VPS..."
+$SSH_CMD "docker pull ${IMAGE_TAG}"
+
+echo "Stopping existing test container (if any)..."
+$SSH_CMD "docker stop crisis-monitor-test && docker rm crisis-monitor-test" || true
+
+echo "Starting new test container..."
+$SSH_CMD "docker run -d \
+  --name crisis-monitor-test \
+  --restart unless-stopped \
+  -p 3001:3000 \
+  -e NODE_ENV=test \
+  -e FRED_API_KEY=${FRED_API_KEY} \
+  -e GIT_SHA=${GITHUB_SHA} \
+  ${IMAGE_TAG}"
+
+echo "Waiting for container to become healthy..."
+TIMEOUT=60
+ELAPSED=0
+until curl -sf "http://${VPS_HOST}:3001/health" > /dev/null 2>&1; do
+  if [ "$ELAPSED" -ge "$TIMEOUT" ]; then
+    echo "Error: Test container did not become healthy within ${TIMEOUT}s."
+    $SSH_CMD "docker logs crisis-monitor-test" || true
+    exit 1
+  fi
+  sleep 2
+  ELAPSED=$((ELAPSED + 2))
+  echo "  waiting... (${ELAPSED}s / ${TIMEOUT}s)"
+done
+
+echo "Test container is healthy."
+
+export BASE_URL="http://${VPS_HOST}:3001"
 export EXPECTED_GIT_SHA="${GITHUB_SHA}"
+
+echo "Running Functional Tests against ${BASE_URL}..."
+npm run test:functional
+
 echo "Running Smoke Tests against ${BASE_URL} (expecting SHA ${EXPECTED_GIT_SHA})..."
 npm run test:smoke
 


### PR DESCRIPTION
## Summary
- **GKE cluster deleted** to cut costs — pipeline now deploys via SSH+Docker to a Hostinger KVM VPS
- Replaced `kubectl apply` / `kubectl rollout` in both deploy scripts with `ssh deploy@VPS_HOST` + `docker pull/stop/rm/run`
- Removed GCP auth (`google-github-actions/auth`, `google-github-actions/get-gke-credentials`) and GCP env vars from the workflow
- Added SSH key write step + `VPS_HOST` and `FRED_API_KEY` secrets to both deploy jobs
- All C3P gates unchanged: unit test gate, SRE approval gate, Evidence Pack generation + artifact upload

## Files Changed
| File | What changed |
|---|---|
| `scripts/deploy_test.sh` | SSH+Docker deploy on port 3001, health poll, functional+smoke tests |
| `scripts/deploy_prod.sh` | SSH+Docker deploy on port 3002, health poll, smoke tests |
| `.github/workflows/ci-cd.yml` | Remove GCP steps/env, add SSH key + VPS secrets |

## New GitHub Secrets Required
| Secret | Purpose |
|---|---|
| `VPS_HOST` | Public IP of Hostinger VPS |
| `VPS_SSH_KEY` | SSH private key for `deploy` user |
| `FRED_API_KEY` | FRED API key (was previously in GKE secrets) |

Secret to **remove**: `GCP_SA_KEY` (no longer used)

## Test plan
- [ ] VPS bootstrapped with Docker + `deploy` user
- [ ] GitHub Secrets (`VPS_HOST`, `VPS_SSH_KEY`, `FRED_API_KEY`) configured
- [ ] PR merge triggers build → test deploy on `:3001` → functional+smoke pass
- [ ] SRE approves → prod deploy on `:3002` → smoke pass → Evidence Pack uploaded
- [ ] `curl http://$VPS_HOST:3001/health` and `:3002/health` return 200 with correct SHA

🤖 Generated with [Claude Code](https://claude.com/claude-code)